### PR TITLE
Remove "from foo import *" from query.py

### DIFF
--- a/query.py
+++ b/query.py
@@ -1,5 +1,4 @@
-from peachpy import *
-from peachpy.x86_64 import *
+import peachpy.x86_64
 
 r = Argument(ptr(const_uint64_t))
 bits = Argument(ptr(const_uint64_t))


### PR DESCRIPTION
"import *" is the Python equivalent of Go's dot imports. We'd rather not
use those, so remove them from the script.

That said, the script is exec'ed inside peachpy.x86_64's scope, so
removing the imports won't actually change anything but code completion
(as peachpy's documentation suggests). You can think of a peachpy
script as being written in a DSL, which happens to be extended by
Python.

I had to keep "import peachpy.x86_64" (which doesn't put anything in the
script's scope, but does execute peachpy.x86_64's init), otherwise the
resulting query_amd64.s changes. Peachpy bug?

Close #1

Signed-off-by: Marcelo E. Magallon marcelo.magallon@gmail.com
