### PR TITLE
avo generator fixes

### DIFF
--- a/asm.go
+++ b/asm.go
@@ -9,8 +9,6 @@ import (
 )
 
 func main() {
-	Package("github.com/dgryski/go-sip13")
-
 	TEXT("queryCore", NOSPLIT, "func(r *[8]uint64, bits [][8]uint64, hashes []uint32)")
 
 	reg_r := GP64()
@@ -47,7 +45,7 @@ func main() {
 	PXOR(xmm_tmp, xmm_tmp)
 
 	for i, r := range xmm_regs {
-		PAND(Mem{Base: idx, Disp: int(r.Bytes()) * i}, r)
+		PAND(Mem{Base: idx, Disp: int(r.Size()) * i}, r)
 	}
 
 	for _, r := range xmm_regs {
@@ -63,7 +61,7 @@ func main() {
 	Label("done")
 
 	for i, r := range xmm_regs {
-		MOVOU(r, Mem{Base: reg_r, Disp: int(r.Bytes()) * i})
+		MOVOU(r, Mem{Base: reg_r, Disp: int(r.Size()) * i})
 	}
 
 	RET()


### PR DESCRIPTION
Replaces calls to register `Bytes()` with `Size()`, to account for the change in mmcloughlin/avo#74.

Removes unnecessary `Package(...)` call that refers to the `go-sip13` package by mistake. `Package()` calls are only needed if you need to refer to types defined in that package.